### PR TITLE
Add steps to install bundler and pods

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,18 @@
 #!/bin/bash
+
+# Step: Bundler
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "Please install bundler before proceeding (run `gem install bundler`)"
+  exit 1
+fi
+bundle install
+
+# Step: Cocoapods
+if ! command -v pod >/dev/null 2>&1; then
+  echo "Please install Cocoapods before proceeding (run `gem install cocoapods`)"
+  exit 1
+fi
+bundle exec pod install
+
+
 cp SampleConfig.swift Config.swift


### PR DESCRIPTION
Partly fixes #8 

Introduces a step that runs `bundle install` and another that runs `bundle exec pod install`. If either Bundler or CocoaPods are not installed the setup fails with a message for the user to install the necessary dependencies.

P.S. This PR is part of my contributions to Hacktoberfest, please add the label `hacktoberfest-accepted` to it 🙏